### PR TITLE
using versioncmp is more future-proof

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,7 @@ class winbind::service (
   ) {
   case $::osfamily {
     'RedHat'  : {
-      if ($::operatingsystemmajrelease != '7') {
+      if versioncmp($::operatingsystemmajrelease, '7') < 0 {
         if ($manage_messagebus_service == true) {
           service { 'messagebus':
             ensure => 'running',


### PR DESCRIPTION
You already fixed the future parser failure, which is how I found this too. This format is more future-proof as RHEL8 will likely be closer to 7 than earlier versions. :)

Thanks!
