### PR TITLE
Hotfix - Add optional winbind separator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,11 +6,24 @@ require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'yamllint/rake_task'
 
-exclude_paths = [
-  "pkg/**/*",
-  "vendor/**/*",
-  "spec/**/*",
-]
+puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'] : ['~> 5.0']
+
+if puppetversion =~ / 4\./
+  exclude_paths = [
+    "pkg/**/*",
+    "plans/**/*",
+    "vendor/**/*",
+    "spec/**/*",
+  ]
+else
+  exclude_paths = [
+    "pkg/**/*",
+    "vendor/**/*",
+    "spec/**/*",
+  ]
+end
+
+
 
 PuppetLint::RakeTask.new :lint do |config|
   config.fail_on_warnings = true

--- a/examples/winbind.pp
+++ b/examples/winbind.pp
@@ -1,17 +1,16 @@
 # Sample profile for controlling domainJoin scripts
-class profiles::join_domain {
-  # Used on selected OS only
-  case $::kernel {
-    'Linux'   : {
-      include ::winbind
-    } # end Linux
+# Used on selected OS only
+case $::kernel {
+  'Linux'   : {
+    include ::winbind
+  } # end Linux
 
-    'Windows' : {
-    }
+  'Windows' : {
+  }
 
-    default : {
-      fail("${::operatingsystem} is not supported.")
-    }
+  default : {
+    fail("${::operatingsystem} is not supported.")
+  }
 
-  } # end case $::kernel
-}
+} # end case $::kernel
+

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -89,13 +89,24 @@ class winbind::config (
   }
 
   if $::osfamily == 'RedHat' {
-    file { '/etc/oddjobd.conf.d/oddjobd-mkhomedir.conf':
-      ensure  => 'file',
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
-      content => template('winbind/oddjobd-mkhomedir.conf.erb'),
-      notify  => Service[['oddjobd', 'winbind',]],
+    if ($manage_oddjob_service == true) {
+      file { '/etc/oddjobd.conf.d/oddjobd-mkhomedir.conf':
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => template('winbind/oddjobd-mkhomedir.conf.erb'),
+        notify  => Service[['oddjobd', 'winbind',]],
+      }
+    } else {
+      file { '/etc/oddjobd.conf.d/oddjobd-mkhomedir.conf':
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => template('winbind/oddjobd-mkhomedir.conf.erb'),
+        notify  => Service['winbind'],
+      }
     }
   }
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -46,6 +46,50 @@ describe 'winbind::config' do
 
   end
 
+  describe 'with winbind separator removed on RedHat' do
+    let :facts do
+      {
+        :kernel                    => 'Linux',
+        :osfamily                  => 'RedHat',
+        :operatingsystem           => 'RedHat',
+        :operatingsystemmajrelease => '7',
+        :fqdn                      => 'SOMEHOST.ad.example.com'
+      }
+    end
+
+    let :pre_condition do
+      "class {'winbind':
+        smb_winbind_separator => '',
+      }"
+    end
+
+    it 'should include share2.conf in smb.conf' do
+      should contain_file('/etc/samba/smb.conf').without_content(/winbind\sseparator\s+ = \+/)
+    end
+
+  end
+
+  describe 'with default winbind separator on RedHat' do
+    let :facts do
+      {
+        :kernel                    => 'Linux',
+        :osfamily                  => 'RedHat',
+        :operatingsystem           => 'RedHat',
+        :operatingsystemmajrelease => '7',
+        :fqdn                      => 'SOMEHOST.ad.example.com'
+      }
+    end
+
+    let :pre_condition do
+      "include winbind"
+    end
+
+    it 'should include default winbind separator in smb.conf' do
+      should contain_file('/etc/samba/smb.conf').with_content(/winbind\sseparator\s+ = \+/)
+    end
+
+  end
+
   describe 'with sharing enabled on RedHat' do
     let :facts do
       {

--- a/templates/smb.conf.erb
+++ b/templates/smb.conf.erb
@@ -22,7 +22,9 @@
   winbind nss info               = <%= @smb_winbind_nss_info %>
   winbind normalize names        = <%= @smb_winbind_normalize_names %>
   winbind offline logon          = <%= @smb_winbind_offline_logon %>
+  <%- if @smb_winbind_separator -%>
   winbind separator              = <%= @smb_winbind_separator %>
+  <%- end -%>
   template homedir               = <%= @smb_template_homedir %>
   template shell                 = <%= @smb_template_shell %>
   idmap config *:backend         = <%= @smb_idmap_config_default_backend %>

--- a/templates/smb.conf.erb
+++ b/templates/smb.conf.erb
@@ -22,7 +22,7 @@
   winbind nss info               = <%= @smb_winbind_nss_info %>
   winbind normalize names        = <%= @smb_winbind_normalize_names %>
   winbind offline logon          = <%= @smb_winbind_offline_logon %>
-  <%- if @smb_winbind_separator -%>
+  <%- if @smb_winbind_separator != '' -%>
   winbind separator              = <%= @smb_winbind_separator %>
   <%- end -%>
   template homedir               = <%= @smb_template_homedir %>


### PR DESCRIPTION
This request is to add the ability to make the `winbind separator` option in `/etc/samba/smb.conf` optional.

This change should not impact existing configurations as the parameter default is unchanged and verified that behavior with tests in 'spec/classes/config_spec.rb'

I also resolved some unrelated test failures.


With the release of RHEL 7.8 and the updated version of `samba-winbind-4.9.1-10` to `samba-winbind-4.10.4-10`, if you are using the `pam_require_membership_of`with group names (i.e. "mygroup"), then the group must now be prepended with the short domain name (i.e. "MYDOMAIN\mygroup"). Additionally, the `winbind separator` option in `smb.conf` must be removed.


> Steps to resolve a host updated to `samba-winbind-4.10.4-10`:
> 1. Add domain name to "require_membership_of =" in /etc/security/pam_winbind.conf (MYDOMAIN\mygroup)
> 2. Remove "winbind separator = +" in /etc/samba/smb.conf
> 3. systemctl stop winbind
> 4. rm -rf /var/lib/samba/*.tdb
> 5. systemctl start winbind

A [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1822810) has also been submitted for this breaking change.

Please let me know what you think of if you would like to see any changes.

Thanks